### PR TITLE
Filter on ip when deleting ovf rules

### DIFF
--- a/libs/CloudscalerLibcloud/CloudscalerLibcloud/utils/network/rules.py
+++ b/libs/CloudscalerLibcloud/CloudscalerLibcloud/utils/network/rules.py
@@ -20,8 +20,8 @@ ovs-ofctl del-flows {bridge} "dl_dst={mac}";
 '''
 
 CLEANUPFLOWS_CMD_IP = '''\
-ovs-ofctl del-flows {bridge} "nw_src={ipaddress}";
-ovs-ofctl del-flows {bridge} "nw_dst={ipaddress}";
+ovs-ofctl del-flows {bridge} "ip,nw_src={ipaddress}";
+ovs-ofctl del-flows {bridge} "ip,nw_dst={ipaddress}";
 '''
 
 GWMGMTINPUT = '''\


### PR DESCRIPTION
If we dont filter on the correct type ovf removes our filter and basicly
nukes all our rules :'(

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>