### PR TITLE
Fixes for import machine

### DIFF
--- a/apps/cloudbroker/base/cloudapi__images/methodclass/cloudapi_images.py
+++ b/apps/cloudbroker/base/cloudapi__images/methodclass/cloudapi_images.py
@@ -81,7 +81,6 @@ class cloudapi_images(BaseActor):
         if images[0]:
             image = self.models.image.new()
             image.load(images[1])
-            return image
         else:
             image = self.models.image.new()
             image.name = name
@@ -91,10 +90,6 @@ class cloudapi_images(BaseActor):
             image.type = 'Linux'
             imageid = self.models.image.set(image)[0]
             image.id = imageid
-            if add_to_all_stacks:
-                # TODO: enhance
-                for stackid in self.models.stack.list():
-                    stack = self.models.stack.get(stackid)
-                    stack.images.append(imageid)
-                    self.models.stack.set(stack)
-            return image
+        if add_to_all_stacks:
+            self.models.stack.updateSearch({'images': {'$ne': image.id}}, {'$addToSet': {'images': image.id}})
+        return image

--- a/apps/cloudbroker/base/cloudapi__machines/methodclass/cloudapi_machines.py
+++ b/apps/cloudbroker/base/cloudapi__machines/methodclass/cloudapi_machines.py
@@ -350,7 +350,7 @@ class cloudapi_machines(BaseActor):
             vm.name = name
             vm.descr = description
             vm.sizeId = sizeId
-            vm.imageId = j.apps.cloudapi.images.get_or_create_by_name('Unknown').id
+            vm.imageId = j.apps.cloudapi.images.get_or_create_by_name('Imported Machine').id
             vm.creationTime = int(time.time())
             vm.updateTime = int(time.time())
             vm.type = 'VIRTUAL'

--- a/libs/CloudscalerLibcloud/CloudscalerLibcloud/compute/drivers/libvirt_driver.py
+++ b/libs/CloudscalerLibcloud/CloudscalerLibcloud/compute/drivers/libvirt_driver.py
@@ -818,7 +818,9 @@ class CSLibvirtNodeDriver(object):
         volumes.append(self._create_metadata_iso(name, password, imagetype))
         return self.init_node(name, size, networkid=networkid, volumes=volumes, imagetype=imagetype)
 
-    def ex_extend_disk(self, diskguid, newsize, disk_info):
+    def ex_extend_disk(self, diskguid, newsize, disk_info=None):
+        if disk_info is None:
+            disk_info = {'machineRefId': None}
         res = self._execute_agent_job('extend_disk',
                                 ovs_connection=self.ovs_connection,
                                 size=newsize,


### PR DESCRIPTION
Make extend disk size diskinfo param optional to be backwards compatible
Always make sure the image for imported machines is available on all
stacks

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>