### PR TITLE
Ignore seclabel during migrate

### DIFF
--- a/libs/agent-scripts/cloudbroker/vm_livemigrate.py
+++ b/libs/agent-scripts/cloudbroker/vm_livemigrate.py
@@ -16,8 +16,8 @@ async = True
 
 def action(vm_id, sourceurl, domainxml, force):
     import libvirt
+    from xml.etree import ElementTree
     from urlparse import urlparse
-    target_con = libvirt.open()  # local
     try:
         source_con = libvirt.open(sourceurl)
     except:
@@ -27,13 +27,19 @@ def action(vm_id, sourceurl, domainxml, force):
     if source_con:
         parsedsourceurl = urlparse(sourceurl)
         localip = j.system.net.getReachableIpAddress(parsedsourceurl.hostname, 22)
+        target_con = libvirt.open(sourceurl.replace(parsedsourceurl.hostname, localip))  # local
         targeturl = "tcp://{}".format(localip)
         domain = source_con.lookupByUUIDString(vm_id)
 
         if domain.state()[0] in (libvirt.VIR_DOMAIN_RUNNING, libvirt.VIR_DOMAIN_PAUSED):
-            flags = libvirt.VIR_MIGRATE_LIVE | libvirt.VIR_MIGRATE_UNDEFINE_SOURCE
+            srcdom = ElementTree.fromstring(domain.XMLDesc(libvirt.VIR_DOMAIN_XML_MIGRATABLE))
+            seclabel = srcdom.find('seclabel')
+            if seclabel is not None:
+                srcdom.remove(seclabel)
+            flags = libvirt.VIR_MIGRATE_LIVE | libvirt.VIR_MIGRATE_UNDEFINE_SOURCE | \
+                    libvirt.VIR_MIGRATE_PEER2PEER
             try:
-                domain.migrate2(target_con, flags=flags, uri=targeturl)
+                domain.migrate2(target_con, flags=flags, dxml=ElementTree.tostring(srcdom), uri=targeturl)
             except:
                 if force:
                     try:
@@ -48,5 +54,14 @@ def action(vm_id, sourceurl, domainxml, force):
             domain.undefine()
             target_con.createXML(domainxml)
     else:
+        target_con = libvirt.open()  # local
         target_con.createXML(domainxml)
     return True
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--vmid')
+    parser.add_argument('--sourceurl')
+    options = parser.parse_args()
+    action(options.vmid, options.sourceurl, '', False)

--- a/scripts/migration/migrateaccounts.py
+++ b/scripts/migration/migrateaccounts.py
@@ -257,6 +257,9 @@ class Migrator(object):
             target = nic.find('target')
             newtarget = newnic.find('target')
             target.attrib['dev'] = newtarget.attrib['dev']
+        seclabel = srcdom.find('seclabel')
+        if seclabel is not None:
+            srcdom.remove(seclabel)
 
         return ElementTree.tostring(srcdom)
 


### PR DESCRIPTION
This allows us to migrate between nodes having apparamor enabled or not
enabled

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>