### PR TITLE
livemigrate do not crahs when domain does not exists

### DIFF
--- a/apps/cbportal/base/cloudbroker__machine/methodclass/cloudbroker_machine.py
+++ b/apps/cbportal/base/cloudbroker__machine/methodclass/cloudbroker_machine.py
@@ -365,7 +365,9 @@ class cloudbroker_machine(BaseActor):
         if vmachine.status != resourcestatus.Machine.HALTED:
             # create network on target node
             node = self.cb.getNode(vmachine, target_provider)
-            target_provider.ex_migrate(node, self.cb.getProviderByStackId(vmachine.stackId), force)
+            migrated = target_provider.ex_migrate(node, self.cb.getProviderByStackId(vmachine.stackId), force)
+            if migrated == -1:
+                vmachine.status = resourcestatus.Machine.HALTED
         vmachine.stackId = targetStackId
         self.models.vmachine.set(vmachine)
 

--- a/libs/CloudscalerLibcloud/CloudscalerLibcloud/compute/drivers/libvirt_driver.py
+++ b/libs/CloudscalerLibcloud/CloudscalerLibcloud/compute/drivers/libvirt_driver.py
@@ -918,9 +918,8 @@ class CSLibvirtNodeDriver(object):
     def ex_migrate(self, node, sourceprovider, force=False):
         domainxml = self.get_xml(node)
         self._ensure_network(node)
-        self._execute_agent_job('vm_livemigrate',
+        return self._execute_agent_job('vm_livemigrate',
                                 vm_id=node.id,
                                 sourceurl=sourceprovider.uri,
                                 force=force,
                                 domainxml=domainxml)
-        return True

--- a/libs/agent-scripts/cloudbroker/vm_livemigrate.py
+++ b/libs/agent-scripts/cloudbroker/vm_livemigrate.py
@@ -29,7 +29,12 @@ def action(vm_id, sourceurl, domainxml, force):
         localip = j.system.net.getReachableIpAddress(parsedsourceurl.hostname, 22)
         target_con = libvirt.open(sourceurl.replace(parsedsourceurl.hostname, localip))  # local
         targeturl = "tcp://{}".format(localip)
-        domain = source_con.lookupByUUIDString(vm_id)
+        try:
+            domain = source_con.lookupByUUIDString(vm_id)
+        except libvirt.libvirtError as e:
+            if e.get_error_code() == libvirt.VIR_ERR_NO_DOMAIN:
+                return -1 # nothing to do domain is not running
+            raise
 
         if domain.state()[0] in (libvirt.VIR_DOMAIN_RUNNING, libvirt.VIR_DOMAIN_PAUSED):
             srcdom = ElementTree.fromstring(domain.XMLDesc(libvirt.VIR_DOMAIN_XML_MIGRATABLE))


### PR DESCRIPTION
When a vm that is halted needs to be migrated we just move the model
only

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>